### PR TITLE
Fix and simplify release signing

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -15,33 +15,21 @@ If you are interested in the iOS version, you can find more information about it
 ## Use the project with your own Firebase instance
 
 1. Clone this repository.
-
-2. Create `signing.properties` file in your `app` folder with the following contents:
-
-    ```
-    storeFile=~/android/debug.keystore  # path to your debug.keystore
-    storePassword=android
-    keyAlias=androiddebugkey
-    keyPassword=android
-    ```
-
-3. Create a new project in the [Firebase console][3].
-
-4. Click *Add Firebase to your Android app*
+- Create a new project in the [Firebase console][3].
+- Click *Add Firebase to your Android app*
   * provide a **unique package name**
   * use the same package name for the **applicationId** in your `build.gradle`
   * insert SHA-1 fingerprint of your debug certificate, otherwise you won't be able to log in
+- Copy the generated *google-services.json* to the `app` folder of your project.
+- You should be able to successfully sync the project now.
+- Copy contents of the `../server/database.rules.json` into your *Firebase -> Database -> Rules* and publish them.
+- Enable **Google sign-in** in your *Firebase -> Auth -> Sign-in Method*.
+- Build and run the app.
 
-5. Copy the generated *google-services.json* to the `app` folder of your project.
+#### Creating a signed release apk (optional)
 
-6. You should be able to successfully sync the project now.
-
-6. Copy contents of the `../server/database.rules.json` into your *Firebase -> Database -> Rules* and publish them.
-
-7. Enable **Google sign-in** in your *Firebase -> Auth -> Sign-in Method*.
-
-8. Build and run the app.
-
+1. `cp app/signing.properties.sample app/signing.properties`
+- Update `app/signing.properties` with your release keystore information
 
 [1]: https://firebase.google.com/
 [2]: /ios

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -12,16 +12,16 @@ android {
         versionName "1.0.0"
         testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
     }
-    def signingConfig = file("signing.properties")
+    def signingProperties = file("signing.properties")
     signingConfigs {
-        if (signingConfig.exists()) {
+        if (signingProperties.exists()) {
+            Properties props = new Properties()
+            props.load(new FileInputStream(signingProperties))
             release {
-                Properties props = new Properties()
-                props.load(new FileInputStream(file("signing.properties")))
-                storeFile file(props['storeFile'])
-                storePassword props['storePassword']
-                keyAlias props['keyAlias']
-                keyPassword props['keyPassword']
+                storeFile file(props.storeFile)
+                storePassword props.storePassword
+                keyAlias props.keyAlias
+                keyPassword props.keyPassword
             }
         }
     }
@@ -29,7 +29,7 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-            if (signingConfig.exists()) {
+            if (signingProperties.exists()) {
                 signingConfig signingConfigs.release
             }
         }

--- a/android/app/signing.properties.sample
+++ b/android/app/signing.properties.sample
@@ -1,0 +1,4 @@
+storeFile=release.keystore
+storePassword=
+keyAlias=
+keyPassword=


### PR DESCRIPTION
There was a naming clash in the `release` block of build.gradle - I renamed `signingConfig` to `signingProperties`.

I also simplified the optional release build instructions, and created a new file `app/signing.properties.sample`. The instructions in the main README.md are now down to two simple steps.
