### PR TITLE
Update to RxJava 2

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -61,7 +61,7 @@ dependencies {
     compile 'com.google.firebase:firebase-config:10.2.6'
     compile 'com.google.android.gms:play-services-auth:10.2.6'
     compile 'com.github.bumptech.glide:glide:3.7.0'
-    compile 'io.reactivex:rxandroid:1.2.0'
+    compile 'io.reactivex.rxjava2:rxandroid:2.0.1'
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.9.5'

--- a/android/app/src/androidTest/java/com/novoda/bonfire/channel/NewChannelActivityTest.java
+++ b/android/app/src/androidTest/java/com/novoda/bonfire/channel/NewChannelActivityTest.java
@@ -27,7 +27,7 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import rx.Observable;
+import io.reactivex.Observable;
 
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.*;

--- a/android/app/src/androidTest/java/com/novoda/bonfire/chat/ChatActivityTest.java
+++ b/android/app/src/androidTest/java/com/novoda/bonfire/chat/ChatActivityTest.java
@@ -26,9 +26,9 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import rx.Observable;
-import rx.android.schedulers.AndroidSchedulers;
-import rx.subjects.PublishSubject;
+import io.reactivex.Observable;
+import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.subjects.PublishSubject;
 
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.*;
@@ -132,7 +132,7 @@ public class ChatActivityTest {
         doAnswer(new Answer<Observable<DatabaseResult<Chat>>>() {
             @Override
             public Observable<DatabaseResult<Chat>> answer(InvocationOnMock invocation) throws Throwable {
-                return subject.asObservable()
+                return subject
                         .observeOn(AndroidSchedulers.mainThread())
                         .startWith(CHAT);
             }

--- a/android/app/src/androidTest/java/com/novoda/bonfire/login/LoginActivityTest.java
+++ b/android/app/src/androidTest/java/com/novoda/bonfire/login/LoginActivityTest.java
@@ -8,6 +8,8 @@ import android.support.test.runner.AndroidJUnit4;
 import com.google.android.gms.common.SignInButton;
 import com.novoda.bonfire.R;
 import com.novoda.bonfire.TestDependencies;
+import com.novoda.bonfire.channel.data.model.Channels;
+import com.novoda.bonfire.channel.service.ChannelService;
 import com.novoda.bonfire.login.data.model.Authentication;
 import com.novoda.bonfire.login.service.LoginService;
 import com.novoda.bonfire.user.data.model.User;
@@ -18,7 +20,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 
-import rx.Observable;
+import io.reactivex.Observable;
 
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
@@ -29,6 +31,8 @@ import static org.mockito.Mockito.when;
 @RunWith(AndroidJUnit4.class)
 public class LoginActivityTest {
 
+    private static final User SUCCESSFUL_AUTH_USER = new User("id", "name", "http://photo.url");
+
     @Rule
     public ActivityTestRule<LoginActivity> activity = new ActivityTestRule<>(LoginActivity.class, false, false);
     private Authentication authentication;
@@ -36,11 +40,15 @@ public class LoginActivityTest {
     @Before
     public void setUp() throws Exception {
         LoginService loginService = Mockito.mock(LoginService.class);
+        ChannelService channelService = Mockito.mock(ChannelService.class);
         authentication = Mockito.mock(Authentication.class);
+
         when(loginService.getAuthentication()).thenReturn(Observable.just(authentication));
+        when(channelService.getChannelsFor(SUCCESSFUL_AUTH_USER)).thenReturn(Observable.<Channels>empty());
 
         TestDependencies.init()
-                .withLoginService(loginService);
+                .withLoginService(loginService)
+                .withChannelService(channelService);
     }
 
     @Test
@@ -67,15 +75,15 @@ public class LoginActivityTest {
 
         activity.launchActivity(new Intent());
 
-        assertThatScreenWIthChannelsIsShown();
+        assertThatScreenWithChannelsIsShown();
     }
 
     private void givenAuthenticationIsSuccessful() {
         when(authentication.isSuccess()).thenReturn(true);
-        when(authentication.getUser()).thenReturn(new User("id", "name", "http://photo.url"));
+        when(authentication.getUser()).thenReturn(SUCCESSFUL_AUTH_USER);
     }
 
-    private ViewInteraction assertThatScreenWIthChannelsIsShown() {
+    private ViewInteraction assertThatScreenWithChannelsIsShown() {
         return onView(withId(R.id.channels)).check(matches(isDisplayed()));
     }
 

--- a/android/app/src/androidTest/java/com/novoda/bonfire/user/UsersActivityTest.java
+++ b/android/app/src/androidTest/java/com/novoda/bonfire/user/UsersActivityTest.java
@@ -30,9 +30,9 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import rx.Observable;
-import rx.android.schedulers.AndroidSchedulers;
-import rx.subjects.PublishSubject;
+import io.reactivex.Observable;
+import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.subjects.PublishSubject;
 
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.click;
@@ -127,7 +127,7 @@ public class UsersActivityTest {
         doAnswer(new Answer<Observable<DatabaseResult<Users>>>() {
             @Override
             public Observable<DatabaseResult<Users>> answer(InvocationOnMock invocation) throws Throwable {
-                return subject.asObservable().observeOn(AndroidSchedulers.mainThread());
+                return subject.observeOn(AndroidSchedulers.mainThread());
             }
         }).when(channelService).getOwnersOfChannel(any(Channel.class));
 

--- a/android/app/src/main/java/com/novoda/bonfire/channel/database/FirebaseChannelsDatabase.java
+++ b/android/app/src/main/java/com/novoda/bonfire/channel/database/FirebaseChannelsDatabase.java
@@ -10,8 +10,9 @@ import com.novoda.bonfire.user.data.model.User;
 import java.util.ArrayList;
 import java.util.List;
 
-import rx.Observable;
-import rx.functions.Func1;
+import io.reactivex.Observable;
+import io.reactivex.annotations.NonNull;
+import io.reactivex.functions.Function;
 
 import static com.novoda.bonfire.channel.database.ChannelConverter.fromFirebaseChannel;
 import static com.novoda.bonfire.channel.database.ChannelConverter.toFirebaseChannel;
@@ -82,19 +83,19 @@ public class FirebaseChannelsDatabase implements ChannelsDatabase {
         return firebaseObservableListeners.listenToValueEvents(ownersDB.child(channel.getName()), getKeys());
     }
 
-    private static Func1<DataSnapshot, Channel> asChannel() {
-        return new Func1<DataSnapshot, Channel>() {
+    private static Function<DataSnapshot, Channel> asChannel() {
+        return new Function<DataSnapshot, Channel>() {
             @Override
-            public Channel call(DataSnapshot dataSnapshot) {
+            public Channel apply(@NonNull DataSnapshot dataSnapshot) throws Exception {
                 return fromFirebaseChannel(dataSnapshot.getValue(FirebaseChannel.class));
             }
         };
     }
 
-    private static Func1<DataSnapshot, List<String>> getKeys() {
-        return new Func1<DataSnapshot, List<String>>() {
+    private static Function<DataSnapshot, List<String>> getKeys() {
+        return new Function<DataSnapshot, List<String>>() {
             @Override
-            public List<String> call(DataSnapshot dataSnapshot) {
+            public List<String> apply(@NonNull DataSnapshot dataSnapshot) throws Exception {
                 List<String> keys = new ArrayList<>();
                 if (dataSnapshot.hasChildren()) {
                     Iterable<DataSnapshot> children = dataSnapshot.getChildren();

--- a/android/app/src/main/java/com/novoda/bonfire/chat/database/FirebaseChatDatabase.java
+++ b/android/app/src/main/java/com/novoda/bonfire/chat/database/FirebaseChatDatabase.java
@@ -11,8 +11,9 @@ import com.novoda.bonfire.rx.FirebaseObservableListeners;
 import java.util.ArrayList;
 import java.util.List;
 
-import rx.Observable;
-import rx.functions.Func1;
+import io.reactivex.Observable;
+import io.reactivex.annotations.NonNull;
+import io.reactivex.functions.Function;
 
 public class FirebaseChatDatabase implements ChatDatabase {
 
@@ -40,10 +41,10 @@ public class FirebaseChatDatabase implements ChatDatabase {
         return messagesDB.child(channel.getName());
     }
 
-    private Func1<DataSnapshot, Chat> toChat() {
-        return new Func1<DataSnapshot, Chat>() {
+    private Function<DataSnapshot, Chat> toChat() {
+        return new Function<DataSnapshot, Chat>() {
             @Override
-            public Chat call(DataSnapshot dataSnapshot) {
+            public Chat apply(@NonNull DataSnapshot dataSnapshot) throws Exception {
                 Iterable<DataSnapshot> children = dataSnapshot.getChildren();
                 List<Message> messages = new ArrayList<>();
                 for (DataSnapshot child : children) {

--- a/android/app/src/main/java/com/novoda/bonfire/login/database/FirebaseAuthDatabase.java
+++ b/android/app/src/main/java/com/novoda/bonfire/login/database/FirebaseAuthDatabase.java
@@ -13,8 +13,9 @@ import com.google.firebase.auth.GoogleAuthProvider;
 import com.novoda.bonfire.login.data.model.Authentication;
 import com.novoda.bonfire.user.data.model.User;
 
-import rx.Observable;
-import rx.Subscriber;
+import io.reactivex.Observable;
+import io.reactivex.ObservableEmitter;
+import io.reactivex.ObservableOnSubscribe;
 
 public class FirebaseAuthDatabase implements AuthDatabase {
 
@@ -26,23 +27,23 @@ public class FirebaseAuthDatabase implements AuthDatabase {
 
     @Override
     public Observable<Authentication> readAuthentication() {
-        return Observable.create(new Observable.OnSubscribe<Authentication>() {
+        return Observable.create(new ObservableOnSubscribe<Authentication>() {
             @Override
-            public void call(Subscriber<? super Authentication> subscriber) {
+            public void subscribe(@NonNull ObservableEmitter<Authentication> emitter) throws Exception {
                 FirebaseUser currentUser = firebaseAuth.getCurrentUser();
                 if (currentUser != null) {
-                    subscriber.onNext(authenticationFrom(currentUser));
+                    emitter.onNext(authenticationFrom(currentUser));
                 }
-                subscriber.onCompleted();
+                emitter.onComplete();
             }
         });
     }
 
     @Override
     public Observable<Authentication> loginWithGoogle(final String idToken) {
-        return Observable.create(new Observable.OnSubscribe<Authentication>() {
+        return Observable.create(new ObservableOnSubscribe<Authentication>() {
             @Override
-            public void call(final Subscriber<? super Authentication> subscriber) {
+            public void subscribe(@NonNull final ObservableEmitter<Authentication> emitter) throws Exception {
                 AuthCredential credential = GoogleAuthProvider.getCredential(idToken, null);
                 firebaseAuth.signInWithCredential(credential)
                         .addOnCompleteListener(new OnCompleteListener<AuthResult>() {
@@ -50,11 +51,11 @@ public class FirebaseAuthDatabase implements AuthDatabase {
                             public void onComplete(@NonNull Task<AuthResult> task) {
                                 if (task.isSuccessful()) {
                                     FirebaseUser firebaseUser = task.getResult().getUser();
-                                    subscriber.onNext(authenticationFrom(firebaseUser));
+                                    emitter.onNext(authenticationFrom(firebaseUser));
                                 } else {
-                                    subscriber.onNext(new Authentication(task.getException()));
+                                    emitter.onNext(new Authentication(task.getException()));
                                 }
-                                subscriber.onCompleted();
+                                emitter.onComplete();
                             }
                         });
             }

--- a/android/app/src/main/java/com/novoda/bonfire/rx/FirebaseObservableListeners.java
+++ b/android/app/src/main/java/com/novoda/bonfire/rx/FirebaseObservableListeners.java
@@ -4,16 +4,16 @@ import com.google.firebase.database.DataSnapshot;
 import com.google.firebase.database.DatabaseReference;
 import com.google.firebase.database.Query;
 
-import rx.Observable;
-import rx.functions.Func1;
+import io.reactivex.Observable;
+import io.reactivex.functions.Function;
 
 public class FirebaseObservableListeners {
 
-    public <T> Observable<T> listenToValueEvents(Query query, Func1<DataSnapshot, T> marshaller) {
+    public <T> Observable<T> listenToValueEvents(Query query, Function<DataSnapshot, T> marshaller) {
         return Observable.create(new ListenToValueEventsOnSubscribe<>(query, marshaller));
     }
 
-    public <T> Observable<T> listenToSingleValueEvents(Query query, Func1<DataSnapshot, T> marshaller) {
+    public <T> Observable<T> listenToSingleValueEvents(Query query, Function<DataSnapshot, T> marshaller) {
         return Observable.create(new ListenToSingleValueOnSubscribe<>(query, marshaller));
     }
 

--- a/android/app/src/main/java/com/novoda/bonfire/user/database/FirebaseUserDatabase.java
+++ b/android/app/src/main/java/com/novoda/bonfire/user/database/FirebaseUserDatabase.java
@@ -10,8 +10,9 @@ import com.novoda.bonfire.user.data.model.Users;
 import java.util.ArrayList;
 import java.util.List;
 
-import rx.Observable;
-import rx.functions.Func1;
+import io.reactivex.Observable;
+import io.reactivex.annotations.NonNull;
+import io.reactivex.functions.Function;
 
 public class FirebaseUserDatabase implements UserDatabase {
 
@@ -43,10 +44,10 @@ public class FirebaseUserDatabase implements UserDatabase {
         usersDB.child(user.getId()).setValue(user); //TODO handle errors
     }
 
-    private Func1<DataSnapshot, Users> toUsers() {
-        return new Func1<DataSnapshot, Users>() {
+    private Function<DataSnapshot, Users> toUsers() {
+        return new Function<DataSnapshot, Users>() {
             @Override
-            public Users call(DataSnapshot dataSnapshot) {
+            public Users apply(@NonNull DataSnapshot dataSnapshot) throws Exception {
                 Iterable<DataSnapshot> children = dataSnapshot.getChildren();
                 List<User> users = new ArrayList<>();
                 for (DataSnapshot child : children) {
@@ -58,10 +59,10 @@ public class FirebaseUserDatabase implements UserDatabase {
         };
     }
 
-    private <T> Func1<DataSnapshot, T> as(final Class<T> tClass) {
-        return new Func1<DataSnapshot, T>() {
+    private <T> Function<DataSnapshot, T> as(final Class<T> tClass) {
+        return new Function<DataSnapshot, T>() {
             @Override
-            public T call(DataSnapshot dataSnapshot) {
+            public T apply(@NonNull DataSnapshot dataSnapshot) throws Exception {
                 return dataSnapshot.getValue(tClass);
             }
         };

--- a/android/app/src/test/java/com/novoda/bonfire/channel/database/FirebaseChannelsDatabaseTest.java
+++ b/android/app/src/test/java/com/novoda/bonfire/channel/database/FirebaseChannelsDatabaseTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import rx.Observable;
+import io.reactivex.Observable;
 
 import static com.novoda.bonfire.helpers.FirebaseTestHelpers.*;
 import static org.mockito.Matchers.any;

--- a/android/app/src/test/java/com/novoda/bonfire/chat/database/FirebaseChatDatabaseTest.java
+++ b/android/app/src/test/java/com/novoda/bonfire/chat/database/FirebaseChatDatabaseTest.java
@@ -15,7 +15,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import rx.Observable;
+import io.reactivex.Observable;
 
 import static com.novoda.bonfire.helpers.FirebaseTestHelpers.*;
 import static org.mockito.Mockito.verify;

--- a/android/app/src/test/java/com/novoda/bonfire/helpers/FirebaseTestHelpers.java
+++ b/android/app/src/test/java/com/novoda/bonfire/helpers/FirebaseTestHelpers.java
@@ -7,9 +7,9 @@ import com.google.firebase.database.DatabaseReference;
 import com.google.firebase.database.FirebaseDatabase;
 import com.novoda.bonfire.rx.FirebaseObservableListeners;
 
-import rx.Observable;
-import rx.functions.Func1;
-import rx.observers.TestSubscriber;
+import io.reactivex.Observable;
+import io.reactivex.functions.Function;
+import io.reactivex.observers.TestObserver;
 
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.when;
@@ -59,23 +59,23 @@ public class FirebaseTestHelpers {
     }
 
     public static <T> void assertValueReceivedOnNext(Observable<T> observable, T expectedValue) {
-        TestSubscriber<T> testSubscriber = testSubscriberFor(observable);
-        testSubscriber.assertValue(expectedValue);
+        TestObserver<T> testObserver = testObserverFor(observable);
+        testObserver.assertValue(expectedValue);
     }
 
     public static <T> void assertThrowableReceivedOnError(Observable<T> observable, Throwable throwable) {
-        TestSubscriber<T> testSubscriber = testSubscriberFor(observable);
-        testSubscriber.assertError(throwable);
+        TestObserver<T> testObserver = testObserverFor(observable);
+        testObserver.assertError(throwable);
     }
 
     @NonNull
-    private static <T> TestSubscriber<T> testSubscriberFor(Observable<T> observable) {
-        TestSubscriber<T> testSubscriber = new TestSubscriber<>();
-        observable.subscribe(testSubscriber);
-        return testSubscriber;
+    private static <T> TestObserver<T> testObserverFor(Observable<T> observable) {
+        TestObserver<T> testObserver = new TestObserver<>();
+        observable.subscribe(testObserver);
+        return testObserver;
     }
 
-    private static <T> Class<Func1<DataSnapshot, T>> marshallerType() {
-        return (Class<Func1<DataSnapshot, T>>) (Class) Func1.class;
+    private static <T> Class<Function<DataSnapshot, T>> marshallerType() {
+        return (Class<Function<DataSnapshot, T>>) (Class) Function.class;
     }
 }

--- a/android/app/src/test/java/com/novoda/bonfire/rx/ListenToValueEventsOnSubscribeTest.java
+++ b/android/app/src/test/java/com/novoda/bonfire/rx/ListenToValueEventsOnSubscribeTest.java
@@ -4,15 +4,14 @@ import com.google.firebase.database.DataSnapshot;
 import com.google.firebase.database.Query;
 import com.google.firebase.database.ValueEventListener;
 
-import java.util.Collections;
-
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import rx.Observable;
-import rx.functions.Func1;
-import rx.observers.TestObserver;
+import io.reactivex.Observable;
+import io.reactivex.annotations.NonNull;
+import io.reactivex.functions.Function;
+import io.reactivex.observers.TestObserver;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
@@ -43,13 +42,13 @@ public class ListenToValueEventsOnSubscribeTest {
         TestObserver<String> testObserver = new TestObserver<>();
         observable.subscribe(testObserver);
 
-        testObserver.assertReceivedOnNext(Collections.singletonList(EXPECTED_KEY));
+        testObserver.assertValues(EXPECTED_KEY);
     }
 
-    private static Func1<DataSnapshot, String> getKey() {
-        return new Func1<DataSnapshot, String>() {
+    private static Function<DataSnapshot, String> getKey() {
+        return new Function<DataSnapshot, String>() {
             @Override
-            public String call(DataSnapshot dataSnapshot) {
+            public String apply(@NonNull DataSnapshot dataSnapshot) throws Exception {
                 return dataSnapshot.getKey();
             }
         };

--- a/android/app/src/test/java/com/novoda/bonfire/user/database/FirebaseUserDatabaseTest.java
+++ b/android/app/src/test/java/com/novoda/bonfire/user/database/FirebaseUserDatabaseTest.java
@@ -13,7 +13,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import rx.Observable;
+import io.reactivex.Observable;
 
 import static com.novoda.bonfire.helpers.FirebaseTestHelpers.*;
 import static org.mockito.Mockito.verify;

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,6 +16,7 @@ buildscript {
 
 allprojects {
     repositories {
+        mavenCentral()
         jcenter()
     }
 }

--- a/android/core/build.gradle
+++ b/android/core/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'java'
 
 dependencies {
-    compile 'io.reactivex:rxjava:1.1.5'
-    compile 'com.jakewharton.rxrelay:rxrelay:1.1.0'
+    compile 'io.reactivex.rxjava2:rxjava:2.1.0'
+    compile 'com.jakewharton.rxrelay2:rxrelay:2.0.0'
     compile 'junit:junit:4.12'
     compile 'org.mockito:mockito-core:1.9.5'
 }

--- a/android/core/src/main/java/com/novoda/bonfire/channel/database/ChannelsDatabase.java
+++ b/android/core/src/main/java/com/novoda/bonfire/channel/database/ChannelsDatabase.java
@@ -5,7 +5,7 @@ import com.novoda.bonfire.user.data.model.User;
 
 import java.util.List;
 
-import rx.Observable;
+import io.reactivex.Observable;
 
 public interface ChannelsDatabase {
 

--- a/android/core/src/main/java/com/novoda/bonfire/channel/presenter/NewChannelPresenter.java
+++ b/android/core/src/main/java/com/novoda/bonfire/channel/presenter/NewChannelPresenter.java
@@ -11,9 +11,10 @@ import com.novoda.bonfire.login.service.LoginService;
 import com.novoda.bonfire.navigation.Navigator;
 import com.novoda.bonfire.user.data.model.User;
 
-import rx.Observable;
-import rx.functions.Action1;
-import rx.subscriptions.CompositeSubscription;
+import io.reactivex.Observable;
+import io.reactivex.annotations.NonNull;
+import io.reactivex.disposables.CompositeDisposable;
+import io.reactivex.functions.Consumer;
 
 public class NewChannelPresenter {
 
@@ -23,7 +24,7 @@ public class NewChannelPresenter {
     private final Navigator navigator;
     private final ErrorLogger errorLogger;
     private User user;
-    private CompositeSubscription subscriptions = new CompositeSubscription();
+    private CompositeDisposable subscriptions = new CompositeDisposable();
 
     public NewChannelPresenter(NewChannelDisplayer newChannelDisplayer,
                                ChannelService channelService,
@@ -40,9 +41,9 @@ public class NewChannelPresenter {
     public void startPresenting() {
         newChannelDisplayer.attach(channelCreationListener);
         subscriptions.add(
-                loginService.getAuthentication().subscribe(new Action1<Authentication>() {
+                loginService.getAuthentication().subscribe(new Consumer<Authentication>() {
                     @Override
-                    public void call(Authentication authentication) {
+                    public void accept(@NonNull Authentication authentication) throws Exception {
                         user = authentication.getUser();
                     }
                 })
@@ -52,7 +53,7 @@ public class NewChannelPresenter {
     public void stopPresenting() {
         newChannelDisplayer.detach(channelCreationListener);
         subscriptions.clear();
-        subscriptions = new CompositeSubscription();
+        subscriptions = new CompositeDisposable();
     }
 
     private NewChannelDisplayer.ChannelCreationListener channelCreationListener = new NewChannelDisplayer.ChannelCreationListener() {
@@ -61,9 +62,9 @@ public class NewChannelPresenter {
         public void onCreateChannelClicked(String channelName, boolean isPrivate) {
             Channel newChannel = new Channel(channelName.trim(), isPrivate ? Access.PRIVATE : Access.PUBLIC);
             subscriptions.add(
-                    create(newChannel).subscribe(new Action1<DatabaseResult<Channel>>() {
+                    create(newChannel).subscribe(new Consumer<DatabaseResult<Channel>>() {
                         @Override
-                        public void call(DatabaseResult<Channel> databaseResult) {
+                        public void accept(@NonNull DatabaseResult<Channel> databaseResult) throws Exception {
                             if (databaseResult.isSuccess()) {
                                 navigator.toChannelWithClearedHistory(databaseResult.getData());
                             } else {

--- a/android/core/src/main/java/com/novoda/bonfire/channel/service/ChannelService.java
+++ b/android/core/src/main/java/com/novoda/bonfire/channel/service/ChannelService.java
@@ -6,7 +6,7 @@ import com.novoda.bonfire.database.DatabaseResult;
 import com.novoda.bonfire.user.data.model.User;
 import com.novoda.bonfire.user.data.model.Users;
 
-import rx.Observable;
+import io.reactivex.Observable;
 
 public interface ChannelService {
 

--- a/android/core/src/main/java/com/novoda/bonfire/chat/database/ChatDatabase.java
+++ b/android/core/src/main/java/com/novoda/bonfire/chat/database/ChatDatabase.java
@@ -4,7 +4,7 @@ import com.novoda.bonfire.channel.data.model.Channel;
 import com.novoda.bonfire.chat.data.model.Chat;
 import com.novoda.bonfire.chat.data.model.Message;
 
-import rx.Observable;
+import io.reactivex.Observable;
 
 public interface ChatDatabase {
 

--- a/android/core/src/main/java/com/novoda/bonfire/chat/service/ChatService.java
+++ b/android/core/src/main/java/com/novoda/bonfire/chat/service/ChatService.java
@@ -5,7 +5,7 @@ import com.novoda.bonfire.chat.data.model.Chat;
 import com.novoda.bonfire.chat.data.model.Message;
 import com.novoda.bonfire.database.DatabaseResult;
 
-import rx.Observable;
+import io.reactivex.Observable;
 
 public interface ChatService {
 

--- a/android/core/src/main/java/com/novoda/bonfire/chat/service/PersistedChatService.java
+++ b/android/core/src/main/java/com/novoda/bonfire/chat/service/PersistedChatService.java
@@ -6,8 +6,9 @@ import com.novoda.bonfire.chat.data.model.Message;
 import com.novoda.bonfire.chat.database.ChatDatabase;
 import com.novoda.bonfire.database.DatabaseResult;
 
-import rx.Observable;
-import rx.functions.Func1;
+import io.reactivex.Observable;
+import io.reactivex.annotations.NonNull;
+import io.reactivex.functions.Function;
 
 public class PersistedChatService implements ChatService {
 
@@ -24,10 +25,10 @@ public class PersistedChatService implements ChatService {
                 .onErrorReturn(DatabaseResult.<Chat>errorAsDatabaseResult());
     }
 
-    private static Func1<Chat, DatabaseResult<Chat>> asDatabaseResult() {
-        return new Func1<Chat, DatabaseResult<Chat>>() {
+    private static Function<Chat, DatabaseResult<Chat>> asDatabaseResult() {
+        return new Function<Chat, DatabaseResult<Chat>>() {
             @Override
-            public DatabaseResult<Chat> call(Chat chat) {
+            public DatabaseResult<Chat> apply(@NonNull Chat chat) throws Exception {
                 return new DatabaseResult<Chat>(chat);
             }
         };

--- a/android/core/src/main/java/com/novoda/bonfire/database/DatabaseResult.java
+++ b/android/core/src/main/java/com/novoda/bonfire/database/DatabaseResult.java
@@ -1,16 +1,17 @@
 package com.novoda.bonfire.database;
 
-import rx.functions.Func1;
+import io.reactivex.annotations.NonNull;
+import io.reactivex.functions.Function;
 
 public class DatabaseResult<T> {
 
     private final Throwable failure;
     private final T data;
 
-    public static  <T> Func1<Throwable, DatabaseResult<T>> errorAsDatabaseResult() {
-        return new Func1<Throwable, DatabaseResult<T>>() {
+    public static  <T> Function<Throwable, DatabaseResult<T>> errorAsDatabaseResult() {
+        return new Function<Throwable, DatabaseResult<T>>() {
             @Override
-            public DatabaseResult<T> call(Throwable throwable) {
+            public DatabaseResult<T> apply(@NonNull Throwable throwable) throws Exception {
                 return new DatabaseResult<>(throwable == null ? new Throwable("Database error is missing") : throwable);
             }
         };

--- a/android/core/src/main/java/com/novoda/bonfire/login/database/AuthDatabase.java
+++ b/android/core/src/main/java/com/novoda/bonfire/login/database/AuthDatabase.java
@@ -2,7 +2,7 @@ package com.novoda.bonfire.login.database;
 
 import com.novoda.bonfire.login.data.model.Authentication;
 
-import rx.Observable;
+import io.reactivex.Observable;
 
 public interface AuthDatabase {
 

--- a/android/core/src/main/java/com/novoda/bonfire/login/displayer/LoginDisplayer.java
+++ b/android/core/src/main/java/com/novoda/bonfire/login/displayer/LoginDisplayer.java
@@ -8,7 +8,7 @@ public interface LoginDisplayer {
 
     void showAuthenticationError(String message);
 
-    public interface LoginActionListener {
+    interface LoginActionListener {
 
         void onGooglePlusLoginSelected();
 

--- a/android/core/src/main/java/com/novoda/bonfire/login/presenter/LoginPresenter.java
+++ b/android/core/src/main/java/com/novoda/bonfire/login/presenter/LoginPresenter.java
@@ -7,8 +7,9 @@ import com.novoda.bonfire.login.displayer.LoginDisplayer;
 import com.novoda.bonfire.login.service.LoginService;
 import com.novoda.bonfire.navigation.LoginNavigator;
 
-import rx.Subscription;
-import rx.functions.Action1;
+import io.reactivex.annotations.NonNull;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.functions.Consumer;
 
 public class LoginPresenter {
 
@@ -18,7 +19,7 @@ public class LoginPresenter {
     private final ErrorLogger errorLogger;
     private final Analytics analytics;
 
-    private Subscription subscription;
+    private Disposable subscription;
 
     public LoginPresenter(LoginService loginService,
                           LoginDisplayer loginDisplayer,
@@ -36,9 +37,9 @@ public class LoginPresenter {
         navigator.attach(loginResultListener);
         loginDisplayer.attach(actionListener);
         subscription = loginService.getAuthentication()
-                .subscribe(new Action1<Authentication>() {
+                .subscribe(new Consumer<Authentication>() {
                     @Override
-                    public void call(Authentication authentication) {
+                    public void accept(@NonNull Authentication authentication) throws Exception {
                         if (authentication.isSuccess()) {
                             navigator.toChannels();
                         } else {
@@ -52,7 +53,7 @@ public class LoginPresenter {
     public void stopPresenting() {
         navigator.detach(loginResultListener);
         loginDisplayer.detach(actionListener);
-        subscription.unsubscribe(); //TODO handle checks
+        subscription.dispose(); //TODO handle checks
     }
 
     private final LoginDisplayer.LoginActionListener actionListener = new LoginDisplayer.LoginActionListener() {

--- a/android/core/src/main/java/com/novoda/bonfire/login/service/LoginService.java
+++ b/android/core/src/main/java/com/novoda/bonfire/login/service/LoginService.java
@@ -2,7 +2,7 @@ package com.novoda.bonfire.login.service;
 
 import com.novoda.bonfire.login.data.model.Authentication;
 
-import rx.Observable;
+import io.reactivex.Observable;
 
 public interface LoginService {
 

--- a/android/core/src/main/java/com/novoda/bonfire/user/database/UserDatabase.java
+++ b/android/core/src/main/java/com/novoda/bonfire/user/database/UserDatabase.java
@@ -3,7 +3,7 @@ package com.novoda.bonfire.user.database;
 import com.novoda.bonfire.user.data.model.User;
 import com.novoda.bonfire.user.data.model.Users;
 
-import rx.Observable;
+import io.reactivex.Observable;
 
 public interface UserDatabase {
 

--- a/android/core/src/main/java/com/novoda/bonfire/user/service/PersistedUserService.java
+++ b/android/core/src/main/java/com/novoda/bonfire/user/service/PersistedUserService.java
@@ -4,7 +4,7 @@ import com.novoda.bonfire.user.data.model.User;
 import com.novoda.bonfire.user.data.model.Users;
 import com.novoda.bonfire.user.database.UserDatabase;
 
-import rx.Observable;
+import io.reactivex.Observable;
 
 public class PersistedUserService implements UserService {
 

--- a/android/core/src/main/java/com/novoda/bonfire/user/service/UserService.java
+++ b/android/core/src/main/java/com/novoda/bonfire/user/service/UserService.java
@@ -3,7 +3,7 @@ package com.novoda.bonfire.user.service;
 import com.novoda.bonfire.user.data.model.User;
 import com.novoda.bonfire.user.data.model.Users;
 
-import rx.Observable;
+import io.reactivex.Observable;
 
 public interface UserService {
 

--- a/android/core/src/main/java/com/novoda/bonfire/welcome/presenter/WelcomePresenter.java
+++ b/android/core/src/main/java/com/novoda/bonfire/welcome/presenter/WelcomePresenter.java
@@ -7,8 +7,9 @@ import com.novoda.bonfire.user.service.UserService;
 import com.novoda.bonfire.welcome.displayer.WelcomeDisplayer;
 import com.novoda.bonfire.welcome.displayer.WelcomeDisplayer.InteractionListener;
 
-import rx.functions.Action1;
-import rx.subscriptions.CompositeSubscription;
+import io.reactivex.annotations.NonNull;
+import io.reactivex.disposables.CompositeDisposable;
+import io.reactivex.functions.Consumer;
 
 public class WelcomePresenter {
 
@@ -18,7 +19,7 @@ public class WelcomePresenter {
     private final Analytics analytics;
     private final String senderId;
 
-    private CompositeSubscription subscriptions = new CompositeSubscription();
+    private CompositeDisposable subscriptions = new CompositeDisposable();
 
     public WelcomePresenter(UserService userService, WelcomeDisplayer welcomeDisplayer, Navigator navigator, Analytics analytics, String senderId) {
         this.userService = userService;
@@ -32,9 +33,9 @@ public class WelcomePresenter {
         welcomeDisplayer.attach(interactionListener);
         analytics.trackInvitationOpened(senderId);
         subscriptions.add(
-                userService.getUser(senderId).subscribe(new Action1<User>() {
+                userService.getUser(senderId).subscribe(new Consumer<User>() {
                     @Override
-                    public void call(User user) {
+                    public void accept(@NonNull User user) throws Exception {
                         welcomeDisplayer.display(user);
                     }
                 })
@@ -44,7 +45,7 @@ public class WelcomePresenter {
     public void stopPresenting() {
         welcomeDisplayer.detach(interactionListener);
         subscriptions.clear(); //TODO sort out checks
-        subscriptions = new CompositeSubscription();
+        subscriptions = new CompositeDisposable();
     }
 
     private final InteractionListener interactionListener = new InteractionListener() {

--- a/android/core/src/test/java/com/novoda/bonfire/channel/service/PersistedChannelServiceTest.java
+++ b/android/core/src/test/java/com/novoda/bonfire/channel/service/PersistedChannelServiceTest.java
@@ -21,8 +21,8 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import rx.Observable;
-import rx.observers.TestObserver;
+import io.reactivex.Observable;
+import io.reactivex.observers.TestObserver;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
@@ -89,7 +89,7 @@ public class PersistedChannelServiceTest {
         TestObserver<Channels> channelsTestObserver = new TestObserver<>();
         channelsObservable.subscribe(channelsTestObserver);
 
-        channelsTestObserver.assertReceivedOnNext(Collections.singletonList(new Channels(expectedList)));
+        channelsTestObserver.assertValues(new Channels(expectedList));
     }
 
     @Test
@@ -153,7 +153,7 @@ public class PersistedChannelServiceTest {
         TestObserver<DatabaseResult<Users>> usersTestObserver = new TestObserver<>();
         channelsObservable.subscribe(usersTestObserver);
 
-        usersTestObserver.assertReceivedOnNext(Collections.singletonList(new DatabaseResult<>(expectedUsersList)));
+        usersTestObserver.assertValues(new DatabaseResult<>(expectedUsersList));
     }
 
     private Users buildExpectedUsers() {


### PR DESCRIPTION
Introduce RxJava 2 by changing all usages of previous classes to the the new ones.

## Details

The most notable changes have been:
* switch from `Observable.OnSubscribe` to `ObservableOnSubscribe`, by using an emitter instead of a subscriber. This means that instead of `add`ing a handler to the `Subscriber`, we're now calling `setCancellable` to provide a hook to clean up the Firebase event listener.
* switch from `Func1` to `Function` and `Predicate`
* switch from `Func2` to `BiFunction`
* switch from `Action1` to `Consumer`
* switch from `Subscription` to `Disposable` (and related sub-classes and methods, such as `isDisposed`)

## Tests

Tests have been minimally changed to make them pass syntactic validation, but their behaviour wasn't touched.

The app still works.  💪 

--------

**NOTE:** this PR does not have to be necessarily merged, I just need a branch to spike on something more interesting and needed RxJava at the latest version.